### PR TITLE
[Blog] Fix navigation so the links don't overlap

### DIFF
--- a/_includes/blog_nav.html
+++ b/_includes/blog_nav.html
@@ -7,7 +7,7 @@
 					{% else %}
 						{% assign previous = forloop.index0 | minus: 1 %}
 						{% assign prev_page = site.posts[previous] %}
-						<a href="{{ prev_page.url }}" class="prev">&lt; Newer: {{prev_page.title|truncate(20)}}</a>
+						<a href="{{ prev_page.url }}" class="prev">&lt; Newer: {{prev_page.title | truncatewords: 5}}</a>
 					{% endif %}
 			</div>
 			<div class="right align-right">
@@ -16,7 +16,7 @@
 					{% else %}
 						{% assign next = forloop.index0 | plus: 1 %}
 						{% assign next_page = site.posts[next] %}
-						<a href="{{ next_page.url }}" class="next">Older: {{next_page.title|truncate(20)}} &gt;</a>
+						<a href="{{ next_page.url }}" class="next">Older: {{next_page.title | truncatewords: 5}} &gt;</a>
 					{% endif %}
 			</div>
 		</div>


### PR DESCRIPTION
- Fix syntax to use truncate: rather than truncate()
- Switch to using truncatewords: for better UX