### PR TITLE
Feb 07 jc

### DIFF
--- a/_solutions/automations/compare-list-differences.md
+++ b/_solutions/automations/compare-list-differences.md
@@ -1,0 +1,52 @@
+---
+title: Compare list differences
+excerpt: Use the `array_diff()` function to find elements unique to a list.
+summary: This page demonstrates how to use the `array_diff()` function to 
+  find elements that exist in one list but not another. This is useful for 
+  identifying new or missing items between two sets of data.
+layout: solution
+jumbotron:
+  breadcrumbs:
+  - label: Resources &raquo;
+    url: /resources/
+  - label: Solutions Hub &raquo;
+    url: /solutions/
+  - label: Automations &raquo;
+    url: /solutions/#automations
+social_image_url: /assets/images/solutions/automations/compare-list-differences.png
+---
+
+{% comment %}
+* Uses `array_diff()` function
+* Compares two lists
+* Identifies unique elements
+{% endcomment %}
+
+## Using array_diff() function
+
+Here is an example of using the [array_diff()](/docs/scripting/functions/#array_diff) function to find elements that exist in the second array but not in the first.
+
+{% tabs compare-list-differences %}
+{% tab compare-list-differences automation %}
+```cerb
+{% raw %}
+start:
+  set:
+    array1@csv: Apple, Google, Microsoft
+    array2@csv: Apple, Microsoft, Cerb
+    diff@csv: {{array_diff(array2, array1)|join(', ')}}
+  return:
+    output: These are new: {{diff|join(', ')}}
+{% endraw %}
+```
+{% endtab %}
+
+{% tab compare-list-differences output %}
+```cerb
+{% raw %}
+__return:
+  output: 'These are new: Cerb'
+{% endraw %}
+```
+{% endtab %}
+{% endtabs %}

--- a/_solutions/automations/format-dates-timezones.md
+++ b/_solutions/automations/format-dates-timezones.md
@@ -1,0 +1,66 @@
+---
+title: Format dates and timezones
+excerpt: Use the `|date` filter to format dates and handle different timezones.
+summary: This page demonstrates how to the `|date` filter to format dates and work with
+  different timezones. Examples include formatting current time,
+  converting between timezones, and using common date format standards like RFC2822
+  and ISO8601.
+layout: solution
+jumbotron:
+  breadcrumbs:
+  - label: Resources &raquo;
+    url: /resources/
+  - label: Solutions Hub &raquo;
+    url: /solutions/
+  - label: Automations &raquo;
+    url: /solutions/#automations
+social_image_url: /assets/images/solutions/automations/format-dates-timezones.png
+---
+
+{% comment %}
+* Formats dates in various styles
+* Handles timezone conversions
+* Supports relative dates
+* Uses standard date formats
+{% endcomment %}
+
+## Using |date filter
+
+Here is an example of using the [\|date](/docs/scripting/filters/#date) filter to format dates and handle different timezones.
+
+You can use any of the formating options from [PHP DateTime::format](https://www.php.net/manual/en/datetime.format.php).
+
+{% tabs format-dates-timezones %}
+
+{% tab format-dates-timezones automation %}
+```cerb
+{% raw %}
+start:
+  return:
+    now: {{'now'|date('F d, Y h:ia T')}}
+    timezone: {{'now'|date('F d, Y h:ia T', 'Europe/Berlin')}}
+    tomorrow: {{'tomorrow 5pm'|date('D, d F Y H:i T')}}
+    two_weeks: {{'+2 weeks 08:00'|date('Y-m-d h:ia T')}}
+    rfc2822: {{'now'|date('r')}}
+    iso8601: {{'now'|date('c')}}
+    unix@int: {{'now'|date('U')}}
+{% endraw %}
+```
+{% endtab %}
+
+{% tab format-dates-timezones output %}
+```cerb
+{% raw %}
+__return:
+  now: February 07, 2025 09:09am PST
+  timezone: February 07, 2025 06:09pm CET
+  tomorrow: Sat, 08 February 2025 17:00 PST
+  two_weeks: 2025-02-21 08:00am PST
+  rfc2822: Fri, 07 Feb 2025 09:09:43 -0800
+  iso8601: "2025-02-07T09:09:43-08:00"
+  unix: 1738948183
+{% endraw %}
+```
+{% endtab %}
+
+{% endtabs %}

--- a/_solutions/automations/modify-dates.md
+++ b/_solutions/automations/modify-dates.md
@@ -1,0 +1,56 @@
+---
+title: Modify dates
+excerpt: Use the `|date_modify` filter to add or subtract units of time from dates.
+summary: This page demonstrates how to use the `|date_modify` filter to perform date 
+  arithmetic. It shows how to add or subtract various time units from dates and format the results.
+layout: solution
+jumbotron:
+  breadcrumbs:
+  - label: Resources &raquo;
+    url: /resources/
+  - label: Solutions Hub &raquo;
+    url: /solutions/
+  - label: Automations &raquo;
+    url: /solutions/#automations
+social_image_url: /assets/images/solutions/automations/modify-dates.png
+---
+
+{% comment %}
+* Uses `|date_modify` filter
+* Supports various time units
+* Handles date formatting
+* Allows multiple modifications
+{% endcomment %}
+
+## Using |date_modify filter
+
+Here is an example of using the [\|date_modify](/docs/scripting/filters/#date_modify) filter to add or subtract units of time from dates.
+
+{% tabs modify-dates %}
+{% tab modify-dates automation %}
+```cerb
+{% raw %}
+start:
+  return:
+    output@text:
+      {% set format = 'D, d M Y T' %}
+      {% set timestamp = date('2025-06-15') %}
+      At: {{timestamp|date(format)}}
+      +2 days: {{timestamp|date_modify('+2 days')|date(format)}}
+      -1 week, 3 days: {{timestamp|date_modify('-1 week, -3 days')|date(format)}}
+{% endraw %}
+```
+{% endtab %}
+
+{% tab modify-dates output %}
+```cerb
+{% raw %}
+__return:
+  output: |-
+    At: Sun, 15 Jun 2025 PDT
+    +2 days: Tue, 17 Jun 2025 PDT
+    -1 week, 3 days: Thu, 05 Jun 2025 PDT
+{% endraw %}
+```
+{% endtab %}
+{% endtabs %}

--- a/_solutions/automations/set-nested-dictionary-keys.md
+++ b/_solutions/automations/set-nested-dictionary-keys.md
@@ -1,0 +1,62 @@
+---
+title: Set nested dictionary keys
+excerpt: Use the `dict_set()` function to set deeply nested keys in dictionaries.
+summary: This page demonstrates how to use the `dict_set()` function to set 
+  deeply nested keys in dictionaries. It shows how to construct complex nested 
+  data structures by setting values at specific paths within a dictionary.
+layout: solution
+jumbotron:
+  breadcrumbs:
+  - label: Resources &raquo;
+    url: /resources/
+  - label: Solutions Hub &raquo;
+    url: /solutions/
+  - label: Automations &raquo;
+    url: /solutions/#automations
+social_image_url: /assets/images/solutions/automations/set-nested-dictionary-keys.png
+---
+
+{% comment %}
+* Uses `dict_set()` function
+* Sets deep nested values
+* Constructs complex dictionaries
+* Maintains dictionary structure
+{% endcomment %}
+
+## Using dict_set() function
+
+Here is an example of using the [dict_set()](/docs/scripting/functions/#dict_set) function to set deeply nested keys in dictionaries.
+
+{% tabs set-nested-dictionary-keys %}
+{% tab set-nested-dictionary-keys automation %}
+```cerb
+{% raw %}
+start:
+  set:
+    worker@json:
+      {% set var = {"group": {}} %}
+      {% set var = dict_set(var, 'group.name', 'Support') %}
+      {% set var = dict_set(var, 'group.manager.name.first', 'Kina') %}
+      {% set var = dict_set(var, 'group.manager.name.last', 'Halpue') %}
+      {{var|json_encode}}
+  return:
+    worker@key: worker
+{% endraw %}
+```
+{% endtab %}
+
+{% tab set-nested-dictionary-keys output %}
+```cerb
+{% raw %}
+__return:
+  worker:
+    group:
+      name: Support
+      manager:
+        name:
+          first: Kina
+          last: Halpue
+{% endraw %}
+```
+{% endtab %}
+{% endtabs %}

--- a/_solutions/automations/trim-whitespace.md
+++ b/_solutions/automations/trim-whitespace.md
@@ -1,0 +1,115 @@
+---
+title: Trim whitespace in scripting tags
+excerpt: Use tag modifiers and `|spaceless` filter to control whitespace.
+summary: This page demonstrates techniques for controlling whitespace. 
+  Learn how to trim leading and trailing whitespace using dash modifiers 
+  in template tags, and remove whitespace between HTML tags using the `|spaceless` filter.
+layout: solution
+jumbotron:
+  breadcrumbs:
+  - label: Resources &raquo;
+    url: /resources/
+  - label: Solutions Hub &raquo;
+    url: /solutions/
+  - label: Automations &raquo;
+    url: /solutions/#automations
+social_image_url: /assets/images/solutions/automations/trim-whitespace.png
+---
+
+{% comment %}
+* Controls whitespace in output
+* Uses tag modifiers for trimming
+* Handles multi-line text
+* Maintains content formatting
+{% endcomment %}
+
+## Using tag modifiers
+
+Adding a dash `-` to opening or closing scripting tags will trim leading or trailing whitespace.
+
+{% tabs trim-whitespace %}
+{% tab trim-whitespace automation %}
+```cerb
+{% raw %}
+start:
+  return:
+    output@text:
+      This text
+      
+      {{-" has no leading or trailing whitespace "-}}
+      
+      in it.
+{% endraw %}
+```
+{% endtab %}
+
+{% tab trim-whitespace output %}
+```cerb
+{% raw %}
+__return:
+  output: This text has no leading or trailing whitespace in it.
+{% endraw %}
+```
+{% endtab %}
+{% endtabs %}
+
+## Using |spaceless filter
+
+The `|spaceless` filter removes whitespace between HTML tags.
+
+{% tabs trim-whitespace2 %}
+{% tab trim-whitespace2 automation %}
+```cerb
+{% raw %}
+start:
+  return:
+    output@text: 
+      {{
+        "<div>
+          <p>This has extra space</p>
+          <p>between tags</p>
+        </div>"|spaceless
+      }}
+{% endraw %}
+```
+{% endtab %}
+
+{% tab trim-whitespace2 output %}
+```cerb
+{% raw %}
+__return:
+  output: <div><p>This has extra space</p><p>between tags</p></div>
+{% endraw %}
+```
+{% endtab %}
+{% endtabs %}
+
+## Using apply spaceless
+
+For larger blocks of HTML, you can use the apply spaceless approach.
+
+{% tabs trim-whitespace3 %}
+{% tab trim-whitespace3 automation %}
+```cerb
+{% raw %}
+start:
+  return:
+    output@text:
+      {% apply spaceless %}
+      <div>
+        <span>This will all be on a single line.</span>
+      </div>
+      {% endapply %}
+{% endraw %}
+```
+{% endtab %}
+
+{% tab trim-whitespace3 output %}
+```cerb
+{% raw %}
+__return:
+  output: <div><span>This will all be on a single line.</span></div>
+{% endraw %}
+```
+{% endtab %}
+{% endtabs %}


### PR DESCRIPTION
For fix 189 I could not get an example working with the one shown here `https://cerb.ai/docs/scripting/commands/#spaceless` but on the twig documentation there are two examples that worked `https://twig.symfony.com/doc/3.x/filters/spaceless.html` The spaceless filter does seem to be deprecated as of Twig 3.12.