### PR TITLE
Metrics

### DIFF
--- a/_docs/metrics/automation.duration.md
+++ b/_docs/metrics/automation.duration.md
@@ -1,0 +1,29 @@
+---
+title: 'Metrics: Automation Duration'
+excerpt: This page provides examples and details on the automation.duration metric
+permalink: /docs/metrics/automation.duration/
+toc:
+  title: automation.duration
+jumbotron:
+  title: automation.duration
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks how long automations take to execute. If you have too many automations with very long execute times on a single event, it can slow down the UI (eg. how long a draft takes to send after pressing the send button or how long a draft editor takes to pop up). You could try to remake the automation so it is more efficient (eg. cutting down on time-expensive search queries) or narrowing down the event bindings so it invokes only when necessary. If you are experiencing UI elements taking longer to run, you should check this metric.
+
+# Dimensions
+
+| Dimension     | Description                                                         |
+|---------------|---------------------------------------------------------------------|
+| automation_id | the automation record                                               |
+| trigger       | the automation trigger (eg `record.changed`)                        |

--- a/_docs/metrics/automation.invocations.md
+++ b/_docs/metrics/automation.invocations.md
@@ -1,0 +1,30 @@
+---
+title: 'Metrics: Automation Invocations'
+excerpt: This page provides examples and details on the automation.invocations metric
+permalink: /docs/metrics/automation.invocations/
+toc:
+  title: automation.invocations
+jumbotron:
+  title: automation.invocations
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks how often automations invoke, on what trigger they invoke and what exit state they produce with each invocation. If an automation invokes overly frequently, especially if it results in an empty `return` exit state (such as when failing a validation check), it may be worth investigating if you can narrow down the activation conditions in the event bindings.
+
+# Dimensions
+
+| Dimension     | Description                                                         |
+|---------------|---------------------------------------------------------------------|
+| automation_id | the automation record                                               |
+| trigger       | the automation trigger (eg `record.changed`)                        |
+| exit_state    | The exit state produced in that invocation (what it ended up doing) |

--- a/_docs/metrics/behavior.duration.md
+++ b/_docs/metrics/behavior.duration.md
@@ -1,0 +1,29 @@
+---
+title: 'Metrics: Behavior Duration'
+excerpt: This page provides examples and details on the behavior.duration metric
+permalink: /docs/metrics/behavior.duration/
+toc:
+  title: behavior.duration
+jumbotron:
+  title: behavior.duration
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks how long your bot behaviors take to execute. Lots of behaviors that take a long time to execute can slow down processes. If you find you have a lot of behaviors with long execution times, especially all on a single event, it may be worth seeing if you can remake them more efficiently as an automation.
+
+# Dimensions
+
+| Dimension   | Description                          |
+|-------------|--------------------------------------|
+| behavior_id | The bot behavior records             |
+| event       | the event that triggers the behavior |

--- a/_docs/metrics/behavior.invocations.md
+++ b/_docs/metrics/behavior.invocations.md
@@ -1,0 +1,29 @@
+---
+title: 'Metrics: Behavior Invocations'
+excerpt: This page provides examples and details on the behavior.invocations metric
+permalink: /docs/metrics/behavior.invocations/
+toc:
+  title: behavior.invocations
+jumbotron:
+  title: behavior.invocations
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks how often any bot behaviors are invoked. These reports can show your most used behaviors, which can be helpful in identifying good candidates to rework into automations.
+
+# Dimensions
+
+| Dimension   | Description                          |
+|-------------|--------------------------------------|
+| behavior_id | The bot behavior records             |
+| event       | the event that triggers the behavior |

--- a/_docs/metrics/mail.routing.rule.matches.md
+++ b/_docs/metrics/mail.routing.rule.matches.md
@@ -29,4 +29,3 @@ This metric tracks the number of times individual mail routing rules, in additio
 | rule_key   | The individual rules (multiple conditions) |
 | node_key   | The individual conditions                  |
 
-# Examples

--- a/_docs/metrics/mail.routing.rule.matches.md
+++ b/_docs/metrics/mail.routing.rule.matches.md
@@ -1,0 +1,32 @@
+---
+title: 'Metrics: Mail Routing Rule Matches'
+excerpt: This page provides examples and details on the mail.routing.rule.matches metric
+permalink: /docs/metrics/mail.routing.rule.matches/
+toc:
+  title: mail.routing.rule.matches
+jumbotron:
+  title: mail.routing.rule.matches
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks the number of times individual mail routing rules, in addition to subrules, are activated. This metric can help you report on the effectiveness of your routing rules. You might find some that are rarely ever hit and may need broadening or eliminating. You also might find some rules that are activated extensively and may benefit from further splitting up into more specific conditions.
+
+# Dimensions
+
+| Dimension  | Description                                |
+|------------|--------------------------------------------|
+| ruleset_id | The full ruleset record (multiple rules)   |
+| rule_key   | The individual rules (multiple conditions) |
+| node_key   | The individual conditions                  |
+
+# Examples

--- a/_docs/metrics/mail.transport.deliveries.md
+++ b/_docs/metrics/mail.transport.deliveries.md
@@ -28,4 +28,3 @@ This metric tracks the number succesful messages sent through each [mail transpo
 | transport_id | The mail transport records                        |
 | sender_id    | The senders (email addresses) that send each mail |
 
-# Examples

--- a/_docs/metrics/mail.transport.deliveries.md
+++ b/_docs/metrics/mail.transport.deliveries.md
@@ -1,0 +1,31 @@
+---
+title: 'Metrics: Mail Transport Deliveries'
+excerpt: This page provides examples and details on the mail.transport.deliveries metric
+permalink: /docs/metrics/mail.transport.deliveries/
+toc:
+  title: mail.transport.deliveries
+jumbotron:
+  title: mail.transport.deliveries
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks the number succesful messages sent through each [mail transport](docs/setup/mail/transports/), as well as each address within them over time. You can see which transport and addresses are your most active and which are the least.
+
+# Dimensions
+
+| Dimension    | Description                                       |
+|--------------|---------------------------------------------------|
+| transport_id | The mail transport records                        |
+| sender_id    | The senders (email addresses) that send each mail |
+
+# Examples

--- a/_docs/metrics/mail.transport.failures.md
+++ b/_docs/metrics/mail.transport.failures.md
@@ -28,4 +28,3 @@ This metric tracks the number of messages send failures occur for each [mail tra
 | transport_id | The mail transport records                        |
 | sender_id    | The senders (email addresses) that send each mail |
 
-# Examples

--- a/_docs/metrics/mail.transport.failures.md
+++ b/_docs/metrics/mail.transport.failures.md
@@ -1,0 +1,31 @@
+---
+title: 'Metrics: Mail Transport Failures'
+excerpt: This page provides examples and details on the mail.transport.failures metric
+permalink: /docs/metrics/mail.transport.failures/
+toc:
+  title: mail.transport.failures
+jumbotron:
+  title: mail.transport.failures
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks the number of messages send failures occur for each [mail transport](docs/setup/mail/transports/), as well as each address within them. This way, you can easily spot any malfunctioning senders or transports. If you have reports of messages failing to send, this is the metric to check.
+
+# Dimensions
+
+| Dimension    | Description                                       |
+|--------------|---------------------------------------------------|
+| transport_id | The mail transport records                        |
+| sender_id    | The senders (email addresses) that send each mail |
+
+# Examples

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -223,7 +223,7 @@ These metrics are managed automatically by Cerb:
 |`cerb.automation.duration`| How long automations are executed. Dimensions: `automation_id` and `trigger`.
 |`cerb.automation.invocations`| How often automations are executed. Dimensions: `automation_id`, `trigger`, `exit_state`.
 |`cerb.behavior.duration`| How long behaviors are executed. Dimensions: `behavior_id` and `event`.
-|`cerb.behavior.invocations`| How often behaviors are executed. Dimensions: `behavior_id` and `event`.
+|[cerb.behavior.invocations](/docs/metrics/behavior.invocations/)| How often behaviors are executed. Dimensions: `behavior_id` and `event`.
 |[cerb.mail.routing.rule.matches](/docs/metrics/mail.routing.rule.matches/)| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).
 |[cerb.mail.transport.deliveries](/docs/metrics/mail.transport.deliveries/)| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |[cerb.mail.transport.failures](/docs/metrics/mail.transport.failures/)| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -224,7 +224,7 @@ These metrics are managed automatically by Cerb:
 |`cerb.automation.invocations`| How often automations are executed. Dimensions: `automation_id`, `trigger`, `exit_state`.
 |`cerb.behavior.duration`| How long behaviors are executed. Dimensions: `behavior_id` and `event`.
 |`cerb.behavior.invocations`| How often behaviors are executed. Dimensions: `behavior_id` and `event`.
- `cerb.mail.routing.rule.matches`| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).
+|[cerb.mail.routing.rule.matches](/docs/metrics/mail.routing.rule.matches/)| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).
 |`cerb.mail.transport.deliveries`| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |[cerb.mail.transport.failures](/docs/metrics/mail.transport.failures/)| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |`cerb.record.search`| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -232,7 +232,7 @@ These metrics are managed automatically by Cerb:
 |`cerb.tickets.open`| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.
 |[cerb.tickets.open.elapsed](/docs/metrics/tickets.open.elapsed/)| How long tickets spent in the open status by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled when an open ticket is moved to a new group/bucket, or an open ticket transitions to a non-open status.
 |`cerb.webhook.invocations`| How often webhooks are executed. Dimensions: `webhook_id` and `client_ip`.
-|`cerb.workers.active`| Seat usage by workers. Dimensions: `worker_id`.
+|[cerb.workers.active](/docs/metrics/workers.active/)| Seat usage by workers. Dimensions: `worker_id`.
 
 # Using metrics in reports
 

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -226,7 +226,7 @@ These metrics are managed automatically by Cerb:
 |`cerb.behavior.invocations`| How often behaviors are executed. Dimensions: `behavior_id` and `event`.
  `cerb.mail.routing.rule.matches`| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).
 |`cerb.mail.transport.deliveries`| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
-|`cerb.mail.transport.failures`| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
+|[cerb.mail.transport.failures](/docs/metrics/mail.transport.failures/)| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |`cerb.record.search`| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.
 |`cerb.snippet.uses`| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.
 |`cerb.tickets.open`| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -230,7 +230,7 @@ These metrics are managed automatically by Cerb:
 |`cerb.record.search`| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.
 |`cerb.snippet.uses`| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.
 |`cerb.tickets.open`| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.
-|`cerb.tickets.open.elapsed`| How long tickets spent in the open status by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled when an open ticket is moved to a new group/bucket, or an open ticket transitions to a non-open status.
+|[cerb.tickets.open.elapsed](/docs/metrics/tickets.open.elapsed/)| How long tickets spent in the open status by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled when an open ticket is moved to a new group/bucket, or an open ticket transitions to a non-open status.
 |`cerb.webhook.invocations`| How often webhooks are executed. Dimensions: `webhook_id` and `client_ip`.
 |`cerb.workers.active`| Seat usage by workers. Dimensions: `worker_id`.
 

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -225,7 +225,7 @@ These metrics are managed automatically by Cerb:
 |`cerb.behavior.duration`| How long behaviors are executed. Dimensions: `behavior_id` and `event`.
 |`cerb.behavior.invocations`| How often behaviors are executed. Dimensions: `behavior_id` and `event`.
 |[cerb.mail.routing.rule.matches](/docs/metrics/mail.routing.rule.matches/)| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).
-|`cerb.mail.transport.deliveries`| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
+|[cerb.mail.transport.deliveries](/docs/metrics/mail.transport.deliveries/)| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |[cerb.mail.transport.failures](/docs/metrics/mail.transport.failures/)| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |`cerb.record.search`| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.
 |[cerb.snippet.uses](/docs/metrics/snippet.uses/)| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -227,7 +227,7 @@ These metrics are managed automatically by Cerb:
 |[cerb.mail.routing.rule.matches](/docs/metrics/mail.routing.rule.matches/)| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).
 |[cerb.mail.transport.deliveries](/docs/metrics/mail.transport.deliveries/)| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |[cerb.mail.transport.failures](/docs/metrics/mail.transport.failures/)| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
-|`cerb.record.search`| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.
+|[cerb.record.search](/docs/metrics/record.search/)| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.
 |[cerb.snippet.uses](/docs/metrics/snippet.uses/)| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.
 |[cerb.tickets.open](/docs/metrics/tickets.open/)| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.
 |[cerb.tickets.open.elapsed](/docs/metrics/tickets.open.elapsed/)| How long tickets spent in the open status by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled when an open ticket is moved to a new group/bucket, or an open ticket transitions to a non-open status.

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -222,7 +222,7 @@ These metrics are managed automatically by Cerb:
 |-|-
 |`cerb.automation.duration`| How long automations are executed. Dimensions: `automation_id` and `trigger`.
 |`cerb.automation.invocations`| How often automations are executed. Dimensions: `automation_id`, `trigger`, `exit_state`.
-|`cerb.behavior.duration`| How long behaviors are executed. Dimensions: `behavior_id` and `event`.
+|[cerb.behavior.duration](/docs/metrics/behavior.duration/)| How long behaviors are executed. Dimensions: `behavior_id` and `event`.
 |[cerb.behavior.invocations](/docs/metrics/behavior.invocations/)| How often behaviors are executed. Dimensions: `behavior_id` and `event`.
 |[cerb.mail.routing.rule.matches](/docs/metrics/mail.routing.rule.matches/)| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).
 |[cerb.mail.transport.deliveries](/docs/metrics/mail.transport.deliveries/)| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -229,7 +229,7 @@ These metrics are managed automatically by Cerb:
 |[cerb.mail.transport.failures](/docs/metrics/mail.transport.failures/)| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |`cerb.record.search`| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.
 |[cerb.snippet.uses](/docs/metrics/snippet.uses/)| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.
-|`cerb.tickets.open`| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.
+|[cerb.tickets.open](/docs/metrics/tickets.open/)| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.
 |[cerb.tickets.open.elapsed](/docs/metrics/tickets.open.elapsed/)| How long tickets spent in the open status by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled when an open ticket is moved to a new group/bucket, or an open ticket transitions to a non-open status.
 |[cerb.webhook.invocations](/docs/metrics/webhook.invocations/)| How often webhooks are executed. Dimensions: `webhook_id` and `client_ip`.
 |[cerb.workers.active](/docs/metrics/workers.active/)| Seat usage by workers. Dimensions: `worker_id`.

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -228,7 +228,7 @@ These metrics are managed automatically by Cerb:
 |`cerb.mail.transport.deliveries`| How many successful messages are sent through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |[cerb.mail.transport.failures](/docs/metrics/mail.transport.failures/)| How many unsuccessful messages are attempted through a mail transport. Dimensions: `transport_id` and `sender_id` (email address).
 |`cerb.record.search`| How often each worker searches for a given record type. Dimensions: `record_type` and `worker_id`.
-|`cerb.snippet.uses`| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.
+|[cerb.snippet.uses](/docs/metrics/snippet.uses/)| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.
 |`cerb.tickets.open`| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.
 |[cerb.tickets.open.elapsed](/docs/metrics/tickets.open.elapsed/)| How long tickets spent in the open status by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled when an open ticket is moved to a new group/bucket, or an open ticket transitions to a non-open status.
 |`cerb.webhook.invocations`| How often webhooks are executed. Dimensions: `webhook_id` and `client_ip`.

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -221,7 +221,7 @@ These metrics are managed automatically by Cerb:
 | Metric | Description
 |-|-
 |`cerb.automation.duration`| How long automations are executed. Dimensions: `automation_id` and `trigger`.
-|`cerb.automation.invocations`| How often automations are executed. Dimensions: `automation_id`, `trigger`, `exit_state`.
+|[cerb.automation.invocations](/docs/metrics/automation.invocations/)| How often automations are executed. Dimensions: `automation_id`, `trigger`, `exit_state`.
 |[cerb.behavior.duration](/docs/metrics/behavior.duration/)| How long behaviors are executed. Dimensions: `behavior_id` and `event`.
 |[cerb.behavior.invocations](/docs/metrics/behavior.invocations/)| How often behaviors are executed. Dimensions: `behavior_id` and `event`.
 |[cerb.mail.routing.rule.matches](/docs/metrics/mail.routing.rule.matches/)| Mail routing rule usage over time. Dimensions: `rule_id` (by ruleset record), `rule_key` (by rule), and `node_key` (by condition).

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -220,7 +220,7 @@ These metrics are managed automatically by Cerb:
 |---
 | Metric | Description
 |-|-
-|`cerb.automation.duration`| How long automations are executed. Dimensions: `automation_id` and `trigger`.
+|[cerb.automation.duration](/docs/metrics/automation.duration/)| How long automations are executed. Dimensions: `automation_id` and `trigger`.
 |[cerb.automation.invocations](/docs/metrics/automation.invocations/)| How often automations are executed. Dimensions: `automation_id`, `trigger`, `exit_state`.
 |[cerb.behavior.duration](/docs/metrics/behavior.duration/)| How long behaviors are executed. Dimensions: `behavior_id` and `event`.
 |[cerb.behavior.invocations](/docs/metrics/behavior.invocations/)| How often behaviors are executed. Dimensions: `behavior_id` and `event`.

--- a/_docs/metrics/metrics.md
+++ b/_docs/metrics/metrics.md
@@ -231,7 +231,7 @@ These metrics are managed automatically by Cerb:
 |[cerb.snippet.uses](/docs/metrics/snippet.uses/)| Snippet usage over time by worker. Dimensions: `snippet_id` and `worker_id`. This replaces the `snippet_use_history` table but imports its data.
 |`cerb.tickets.open`| Open ticket counts over time by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled every 15 minutes.
 |[cerb.tickets.open.elapsed](/docs/metrics/tickets.open.elapsed/)| How long tickets spent in the open status by group and bucket. Dimensions: `group_id` and `bucket_id`. The metric is sampled when an open ticket is moved to a new group/bucket, or an open ticket transitions to a non-open status.
-|`cerb.webhook.invocations`| How often webhooks are executed. Dimensions: `webhook_id` and `client_ip`.
+|[cerb.webhook.invocations](/docs/metrics/webhook.invocations/)| How often webhooks are executed. Dimensions: `webhook_id` and `client_ip`.
 |[cerb.workers.active](/docs/metrics/workers.active/)| Seat usage by workers. Dimensions: `worker_id`.
 
 # Using metrics in reports

--- a/_docs/metrics/record.search.md
+++ b/_docs/metrics/record.search.md
@@ -1,0 +1,29 @@
+---
+title: 'Metrics: Record Search'
+excerpt: This page provides examples and details on the record.search metric
+permalink: /docs/metrics/record.search/
+toc:
+  title: record.search
+jumbotron:
+  title: record.search
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks the how often a worker searches for a particular record type. This can be filtered by both record type and by worker.
+
+# Dimensions
+
+| Dimension   | Description       |
+|-------------|-------------------|
+| record_type | the record type   |
+| worker_id   | the worker record |

--- a/_docs/metrics/snippet.uses.md
+++ b/_docs/metrics/snippet.uses.md
@@ -1,0 +1,31 @@
+---
+title: 'Metrics: Snippet Uses'
+excerpt: This page provides examples and details on the snippet.uses metric
+permalink: /docs/metrics/snippet.uses/
+toc:
+  title: snippet.uses
+jumbotron:
+  title: snippet.uses
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks the number of times snippets are used, both by the snippet and by the worker using them. This way, you can track if certain snippets are being used more or less than others, potentially identifying snippets that may need improving.
+
+# Dimensions
+
+| Dimension  | Description                    |
+|------------|--------------------------------|
+| snippet_id | The snippet records            |
+| worker_id  | the workers using the snippets |
+
+# Examples

--- a/_docs/metrics/snippet.uses.md
+++ b/_docs/metrics/snippet.uses.md
@@ -28,4 +28,3 @@ This metric tracks the number of times snippets are used, both by the snippet an
 | snippet_id | The snippet records            |
 | worker_id  | the workers using the snippets |
 
-# Examples

--- a/_docs/metrics/snippet.uses.md
+++ b/_docs/metrics/snippet.uses.md
@@ -27,4 +27,3 @@ This metric tracks the number of times snippets are used, both by the snippet an
 |------------|--------------------------------|
 | snippet_id | The snippet records            |
 | worker_id  | the workers using the snippets |
-

--- a/_docs/metrics/tickets.open.elapsed.md
+++ b/_docs/metrics/tickets.open.elapsed.md
@@ -33,5 +33,3 @@ This can also be useful if a ticket spends time somewhere that extended waits ar
 |-----------|---------------------------------|
 | group_id  | The IDs of the relevant groups  |
 | bucket_id | The IDs of the relevant buckets |
-
-# Examples

--- a/_docs/metrics/tickets.open.elapsed.md
+++ b/_docs/metrics/tickets.open.elapsed.md
@@ -1,0 +1,37 @@
+---
+title: 'Metrics: Tickets Open Elapsed'
+excerpt: This page provides examples and details on the tickets.open.elapsed metric
+permalink: /docs/metrics/tickets.open.elapsed/
+toc:
+  title: tickets.open.elapsed
+jumbotron:
+  title: tickets.open.elapsed
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+Knowing how long a ticket sits in the `Open` status is important information. After all, if a ticket is in the open status, that means a customer is waiting for a response. Knowing how long a ticket spends open in general is useful knowledge, but it is more important to know how long tickets spend open per group or bucket. That way you can discover any potential bottlenecks or places where performance needs improving. That's where the `tickets.open.elapsed` metric comes in.
+
+In the past, `time spent open` was a single entry on a ticket and was applied to whatever group or bucket the ticket currently resided. This could lead to report results that painted an incorrect picture. If a ticket were to sit in Triage for a day before being handed off to the Bugs team, who responds in five minutes, simply saying that the ticket was open for a day and five minutes does not show you the full picture.
+
+The `tickets.open.elapsed` metric samples whenever a ticket is moved to a different group/bucket or when the ticket moves to a non-open status (eg `waiting` or `closed`). In our above example, the ticket sits in Triage for a day. Upon moving to the Bug team, the metric is sampled and one day is added to the Triage group. Then, the Bug team responds in five minutes and the ticket is closed. The metric is sampled again, this time adding five minutes to the Bug team. Now you have the proper information needed to investigate why Triage is taking a full day to process tickets, not why the Bug team is taking over a day to respond to them.
+
+This can also be useful if a ticket spends time somewhere that extended waits are expected, such as "developer help" bucket that is only checked once per week. In this case, a Support team, for example, is not penalized for time the ticket is outside of their control.
+
+# Dimensions
+
+| Dimension | Description                     |
+|-----------|---------------------------------|
+| group_id  | The IDs of the relevant groups  |
+| bucket_id | The IDs of the relevant buckets |
+
+# Examples

--- a/_docs/metrics/tickets.open.md
+++ b/_docs/metrics/tickets.open.md
@@ -1,0 +1,29 @@
+---
+title: 'Metrics: Tickets Open'
+excerpt: This page provides examples and details on the tickets.open metric
+permalink: /docs/metrics/tickets.open/
+toc:
+  title: tickets.open
+jumbotron:
+  title: tickets.open
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks the number of tickets open over time. It can be both broken down and filtered by group and bucket. This metric is different from a regular `worklist.subtotals` query as it is sampled every 15 minutes rather than being queried in real time. When dealing with large datasets over long periods of time, this can lead to far more efficiently generated reports than realtime queries.
+
+# Dimensions
+
+| Dimension | Description                     |
+|-----------|---------------------------------|
+| group_id  | the group record of the ticket  |
+| bucket_id | the bucket record of the ticket |

--- a/_docs/metrics/webhook.invocations.md
+++ b/_docs/metrics/webhook.invocations.md
@@ -1,0 +1,29 @@
+---
+title: 'Metrics: Webhook Invocations'
+excerpt: This page provides examples and details on the webhook.invocations metric
+permalink: /docs/metrics/webhook.invocations/
+toc:
+  title: webhook.invocations
+jumbotron:
+  title: webhook.invocations
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks how often your webhooks are hit. This metric provides an easy way to find your most and least used webhooks. With that information, you can remove any webhooks that are no longer used.
+
+# Dimensions
+
+| Dimension  | Description                                 |
+|------------|---------------------------------------------|
+| webhook_id | the webhook listener record                 |
+| client_ip  | the ip of the services pinging the webhooks |

--- a/_docs/metrics/workers.active.md
+++ b/_docs/metrics/workers.active.md
@@ -1,0 +1,28 @@
+---
+title: 'Metrics: Workers Active'
+excerpt: This page provides examples and details on the workers.active metric
+permalink: /docs/metrics/workers.active/
+toc:
+  title: workers.active
+jumbotron:
+  title: workers.active
+  tagline: ~
+  breadcrumbs:
+  - label: Docs &raquo;
+    url: /docs/home/
+  - label: Metrics &raquo;
+    url: /docs/metrics/
+---
+
+* TOC
+{:toc}
+
+# Description
+
+This metric tracks seat usage across workers. You can use these reports to see how efficiently you are making use of your seat allocations, whether your number of seats needs adjusting and busy times in your organization. You can filter the metric by individual workers or groups of workers to see their activity.
+
+# Dimensions
+
+| Dimension | Description       |
+|-----------|-------------------|
+| worker_id | the worker record |


### PR DESCRIPTION
Created documentation pages for all built-in metric types. These describe the metric and leave space for examples, should we want to add later.